### PR TITLE
becker/lock-mq-msg

### DIFF
--- a/migrations/20220208000504_lock-messages.down.sql
+++ b/migrations/20220208000504_lock-messages.down.sql
@@ -1,0 +1,60 @@
+-- Add down migration script here
+CREATE OR REPLACE FUNCTION mq_poll(channel_names TEXT[], batch_size INT DEFAULT 1)
+RETURNS TABLE(
+    id UUID,
+    is_committed BOOLEAN,
+    name TEXT,
+    payload_json TEXT,
+    payload_bytes BYTEA,
+    retry_backoff INTERVAL,
+    wait_time INTERVAL
+) AS $$
+BEGIN
+    RETURN QUERY UPDATE mq_msgs
+    SET
+        attempt_at = CASE WHEN mq_msgs.attempts = 1 THEN NULL ELSE NOW() + mq_msgs.retry_backoff END,
+        attempts = mq_msgs.attempts - 1,
+        retry_backoff = mq_msgs.retry_backoff * 2
+    FROM (
+        SELECT
+            msgs.id
+        FROM mq_active_channels(channel_names, batch_size) AS active_channels
+        INNER JOIN LATERAL (
+            SELECT * FROM mq_msgs
+            WHERE mq_msgs.id != uuid_nil()
+            AND mq_msgs.attempt_at <= NOW()
+            AND mq_msgs.channel_name = active_channels.name
+            AND mq_msgs.channel_args = active_channels.args
+            AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+            ORDER BY mq_msgs.attempt_at ASC
+            LIMIT batch_size
+        ) AS msgs ON TRUE
+        LIMIT batch_size
+    ) AS messages_to_update
+    LEFT JOIN mq_payloads ON mq_payloads.id = messages_to_update.id
+    WHERE mq_msgs.id = messages_to_update.id
+    RETURNING
+        mq_msgs.id,
+        mq_msgs.commit_interval IS NULL,
+        mq_payloads.name,
+        mq_payloads.payload_json::TEXT,
+        mq_payloads.payload_bytes,
+        mq_msgs.retry_backoff / 2,
+        interval '0' AS wait_time;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT
+            NULL::UUID,
+            NULL::BOOLEAN,
+            NULL::TEXT,
+            NULL::TEXT,
+            NULL::BYTEA,
+            NULL::INTERVAL,
+            MIN(mq_msgs.attempt_at) - NOW()
+        FROM mq_msgs
+        WHERE mq_msgs.id != uuid_nil()
+        AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+        AND (channel_names IS NULL OR mq_msgs.channel_name = ANY(channel_names));
+    END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/20220208000504_lock-messages.up.sql
+++ b/migrations/20220208000504_lock-messages.up.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION mq_poll(channel_names TEXT[], batch_size INT DEFAULT 1)
+RETURNS TABLE(
+    id UUID,
+    is_committed BOOLEAN,
+    name TEXT,
+    payload_json TEXT,
+    payload_bytes BYTEA,
+    retry_backoff INTERVAL,
+    wait_time INTERVAL
+) AS $$
+BEGIN
+    RETURN QUERY UPDATE mq_msgs
+    SET
+        attempt_at = CASE WHEN mq_msgs.attempts = 1 THEN NULL ELSE NOW() + mq_msgs.retry_backoff END,
+        attempts = mq_msgs.attempts - 1,
+        retry_backoff = mq_msgs.retry_backoff * 2
+    FROM (
+        SELECT
+            msgs.id
+        FROM mq_active_channels(channel_names, batch_size) AS active_channels
+        INNER JOIN LATERAL (
+            SELECT * FROM mq_msgs
+            WHERE mq_msgs.id != uuid_nil()
+            AND mq_msgs.attempt_at <= NOW()
+            AND mq_msgs.channel_name = active_channels.name
+            AND mq_msgs.channel_args = active_channels.args
+            AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+            ORDER BY mq_msgs.attempt_at ASC
+            LIMIT batch_size
+        ) AS msgs ON TRUE
+        LIMIT batch_size FOR UPDATE
+    ) AS messages_to_update
+    LEFT JOIN mq_payloads ON mq_payloads.id = messages_to_update.id
+    WHERE mq_msgs.id = messages_to_update.id
+    RETURNING
+        mq_msgs.id,
+        mq_msgs.commit_interval IS NULL,
+        mq_payloads.name,
+        mq_payloads.payload_json::TEXT,
+        mq_payloads.payload_bytes,
+        mq_msgs.retry_backoff / 2,
+        interval '0' AS wait_time;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT
+            NULL::UUID,
+            NULL::BOOLEAN,
+            NULL::TEXT,
+            NULL::TEXT,
+            NULL::BYTEA,
+            NULL::INTERVAL,
+            MIN(mq_msgs.attempt_at) - NOW()
+        FROM mq_msgs
+        WHERE mq_msgs.id != uuid_nil()
+        AND NOT mq_uuid_exists(mq_msgs.after_message_id)
+        AND (channel_names IS NULL OR mq_msgs.channel_name = ANY(channel_names));
+    END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/sqlxmq_stress/README
+++ b/sqlxmq_stress/README
@@ -1,0 +1,8 @@
+# Create database
+database url is set in .env
+
+`pqsl -c 'create database sqlxmq_stress'`
+
+# run migrations
+
+`sqlx migrate run`

--- a/sqlxmq_stress/migrations/20210316025847_setup.up.sql
+++ b/sqlxmq_stress/migrations/20210316025847_setup.up.sql
@@ -127,7 +127,7 @@ BEGIN
             AND mq_msgs.channel_args = active_channels.args
             AND NOT mq_uuid_exists(mq_msgs.after_message_id)
             ORDER BY mq_msgs.attempt_at ASC
-            LIMIT batch_size
+            LIMIT batch_size FOR UPDATE
         ) AS msgs ON TRUE
         LIMIT batch_size
     ) AS messages_to_update


### PR DESCRIPTION
Dearest Reviewer,

A possible fix for issue #23. If the mq_poll was called within the same
microsecond it is possible they both return the same results. Locking
the mq_msg for update holds them for the `BEGIN...END` of the function
return. I did notice a slight slowdown on my branches vs main but I
think its better to not reprocess a job.

This branch:
```stress
min: 0.068051966s
max: 41.474278327s
median: 32.28066282s
95th percentile: 39.407505295s
throughput: 239.26637244549013/s
```

Main:
```stress
min: 0.038561309s
max: 37.321387572s
median: 29.594086093s
95th percentile: 34.564979967s
throughput: 263.7400277852498/s
```

Thanks
Becker

Ps: If reading issue 23 my coworker has confirmed this change does prevent
the dup processing for them.

It is hard to tell but its adding a FOR UPDATE in the SELECT * FROM mq_msgs
https://github.com/StructionSite/sqlxmq/pull/1/files#diff-0caca38de8ed18e06509d8461abe4f9a4dac0a3075dba8976ae68d90ee255b7aR31